### PR TITLE
Updated progressBar.js to display hours instead of just minutes

### DIFF
--- a/progressBar.js
+++ b/progressBar.js
@@ -79,7 +79,10 @@ export class ProgressBarManager extends Slider {
 
                 let progressBar = new ProgressBar(0, this, name, [timestamp1, timestamp2]);
                 let box = new St.BoxLayout();
-                timestamp2.set_text(`${Math.floor(length)}:${Math.floor((length - Math.floor(length))*60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false})}`);
+                let hours = Math.floor(length / 60);
+                timestamp2.set_text(`${hours > 0 ? hours + ':' : ''}${
+                    hours > 0 ? (Math.floor(length) % 60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false}) : (Math.floor(length) % 60)}:${
+                    Math.floor((length - Math.floor(length))*60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false})}`);
                 box.add_child(timestamp1);
                 box.add_child(progressBar);
                 box.add_child(timestamp2);
@@ -173,7 +176,10 @@ export class ProgressBar extends Slider {
 
             this.value = position / this._length;
             position = position / 60000000;
-            this.timestamps[0].set_text(`${Math.floor(position)}:${Math.floor((position - Math.floor(position))*60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false})}`);
+            let hours = Math.floor(position / 60);
+            this.timestamps[0].set_text(`${hours > 0 ? hours + ':' : ''}${
+                hours > 0 ? (Math.floor(position) % 60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false}) : (Math.floor(position) % 60)}:${
+                Math.floor((position - Math.floor(position))*60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false})}`);
         }, 1000);
 
         this.signals.push(this.connect("drag-end", () => {
@@ -201,7 +207,12 @@ export class ProgressBar extends Slider {
             this.timestamps[0].visible = true;
             this.timestamps[1].visible = true;
         }
-        this.timestamps[1].set_text(`${Math.floor(this._length / 60000000)}:${Math.floor((this._length / 60000000 - Math.floor(this._length / 60000000))*60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false})}`);
+
+        let position = this._length / 60000000;
+        let hours = Math.floor(position / 60);
+        this.timestamps[1].set_text(`${hours > 0 ? hours + ':' : ''}${
+            hours > 0 ? (Math.floor(position) % 60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false}) : (Math.floor(position) % 60)}:${
+            Math.floor((position - Math.floor(position))*60).toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false})}`);
     }
 
     getProperty(prop) {


### PR DESCRIPTION
Hello, I've made a minor change that displays hours, minutes and seconds for media that is 1 hour or longer. See screenshots below:
![image](https://github.com/Krypion17/media-progress/assets/40526225/a91a9365-122d-4146-a806-ad557bf668a0)
![image](https://github.com/Krypion17/media-progress/assets/40526225/6dcfec33-f2e8-421c-a847-bc2453899083)
![image](https://github.com/Krypion17/media-progress/assets/40526225/e6d38097-4e75-44c4-b90a-5f2ed8615fa8)
![image](https://github.com/Krypion17/media-progress/assets/40526225/051dfcad-e1f1-4c42-ab94-d5b6a0bca4aa)

If it is of any use for testing purposes, I used Rhythmbox to play the file and the files were obtained from [here](https://github.com/anars/blank-audio/tree/master).