### PR TITLE
Check PlaybackStatus before updating the progress bar.

### DIFF
--- a/progressBar.js
+++ b/progressBar.js
@@ -147,12 +147,14 @@ export class ProgressBar extends Slider {
         this.interval = setInterval(() => {
             if (this._dragging)
                 return;
-            if (this.getProperty("PlaybackStatus") !== "Playing")
-                return;
             if (!this.length)
                 this._updateInfo();
 
-            let position = this.getProperty("Position");
+            let position;
+            if (this.getProperty("PlaybackStatus") === "Playing")
+                position = this.getProperty("Position");
+            else
+                position = this.value * this._length;
 
             this.value = position / this._length;
             position = position / 1000000;


### PR DESCRIPTION
This is a workaround for programs with buggy MPRIS implementations like Firefox. It's been broken upstream for so long that i think implementing a simple workaround is reasonable.
See https://github.com/Krypion17/media-progress/issues/14