### PR TITLE
Fix compositor deadlocks

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -20,7 +20,7 @@ export default class mediaProgress extends Extension {
         this.unlockManager?.destroy();
         this.unlockManager = null;
         this.notifBox = null;
-        if (!this.message_view)
+        if (!this.message_view?._mediaSource || !this.message_view?.messages)
             return;
 
         this.progressBarManager = new ProgressBarManager(this.message_view._mediaSource, this.message_view.messages);
@@ -41,16 +41,23 @@ export default class mediaProgress extends Extension {
 
         this._unlockNotificationBox = this.notifBox._notificationBox;
         this._unlockSignalId = this._unlockNotificationBox.connect(CHILD_ADDED_SIGNAL, () => {
-            this._unlockNotificationBox?.disconnect(this._unlockSignalId);
+            try {
+                this._unlockNotificationBox?.disconnect(this._unlockSignalId);
+            } catch {}
             this._unlockSignalId = null;
             this._unlockNotificationBox = null;
             // The messages are loaded in slightly late
             // So we wait for the first one to get added and initialise
+            if (!this.notifBox?._mediaSource || !this.notifBox?._notificationBox)
+                return;
             this.unlockManager = new ProgressBarManager(this.notifBox._mediaSource, this.notifBox._notificationBox);
         });
     }
 
     _onSessionModeChange(session) {
+        if (!session)
+            return;
+
         if (session.currentMode === SESSION_MODE_USER || session.parentMode === SESSION_MODE_USER)
             this._user();
         else if (session.currentMode === SESSION_MODE_UNLOCK_DIALOG)
@@ -58,7 +65,7 @@ export default class mediaProgress extends Extension {
     }
 
     enable() {
-        this.message_view = Main.panel.statusArea.dateMenu._messageList._messageView;
+        this.message_view = Main.panel?.statusArea?.dateMenu?._messageList?._messageView ?? null;
         this._onSessionModeChange(Main.sessionMode);
 
         this._sessionId = Main.sessionMode.connect(SESSION_UPDATED_SIGNAL, this._onSessionModeChange.bind(this));
@@ -73,7 +80,9 @@ export default class mediaProgress extends Extension {
         }
 
         if (this._unlockSignalId && this._unlockNotificationBox) {
-            this._unlockNotificationBox.disconnect(this._unlockSignalId);
+            try {
+                this._unlockNotificationBox.disconnect(this._unlockSignalId);
+            } catch {}
             this._unlockSignalId = null;
             this._unlockNotificationBox = null;
         }

--- a/extension.js
+++ b/extension.js
@@ -1,27 +1,49 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import { ProgressBarManager as ProgressBarManager, ProgressBar as ProgressBar } from "./progressBar.js";
-import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import { ProgressBarManager } from "./progressBar.js";
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const SESSION_MODE_USER = "user";
+const SESSION_MODE_UNLOCK_DIALOG = "unlock-dialog";
+const SESSION_UPDATED_SIGNAL = "updated";
+const CHILD_ADDED_SIGNAL = "child-added";
 
 export default class mediaProgress extends Extension {
     constructor(metadata) {
         super(metadata);
 
-        this.message_view = Main.panel.statusArea.dateMenu._messageList._messageView;
+        this.message_view = null;
+        this._unlockSignalId = null;
+        this._unlockNotificationBox = null;
     }
 
     _user() {
         this.unlockManager?.destroy();
         this.unlockManager = null;
         this.notifBox = null;
+        if (!this.message_view)
+            return;
+
         this.progressBarManager = new ProgressBarManager(this.message_view._mediaSource, this.message_view.messages);
     }
 
     _unlockDialog() {
         this.progressBarManager?.destroy();
         this.progressBarManager = null;
-        this.notifBox = Main.screenShield._dialog._notificationsBox;
-        const loadSignal = this.notifBox._notificationBox.connect("child-added", () => {
-            this.notifBox._notificationBox.disconnect(loadSignal);
+        this.notifBox = Main.screenShield?._dialog?._notificationsBox;
+        if (!this.notifBox?._notificationBox)
+            return;
+
+        if (this._unlockSignalId && this._unlockNotificationBox) {
+            this._unlockNotificationBox.disconnect(this._unlockSignalId);
+            this._unlockSignalId = null;
+            this._unlockNotificationBox = null;
+        }
+
+        this._unlockNotificationBox = this.notifBox._notificationBox;
+        this._unlockSignalId = this._unlockNotificationBox.connect(CHILD_ADDED_SIGNAL, () => {
+            this._unlockNotificationBox?.disconnect(this._unlockSignalId);
+            this._unlockSignalId = null;
+            this._unlockNotificationBox = null;
             // The messages are loaded in slightly late
             // So we wait for the first one to get added and initialise
             this.unlockManager = new ProgressBarManager(this.notifBox._mediaSource, this.notifBox._notificationBox);
@@ -29,24 +51,31 @@ export default class mediaProgress extends Extension {
     }
 
     _onSessionModeChange(session) {
-        if (session.currentMode === "user" || session.parentMode === "user")
+        if (session.currentMode === SESSION_MODE_USER || session.parentMode === SESSION_MODE_USER)
             this._user();
-        else if (session.currentMode === "unlock-dialog")
+        else if (session.currentMode === SESSION_MODE_UNLOCK_DIALOG)
             this._unlockDialog();
     }
 
     enable() {
+        this.message_view = Main.panel.statusArea.dateMenu._messageList._messageView;
         this._onSessionModeChange(Main.sessionMode);
 
-        this._sessionId = Main.sessionMode.connect('updated', this._onSessionModeChange.bind(this));
+        this._sessionId = Main.sessionMode.connect(SESSION_UPDATED_SIGNAL, this._onSessionModeChange.bind(this));
     }
 
     disable() {
-        // unlock-dialog session mode use required to add progress bar to lockscreen media message 
+        // unlock-dialog session mode use required to add progress bar to lockscreen media message
 
         if (this._sessionId) {
             Main.sessionMode.disconnect(this._sessionId);
             this._sessionId = null;
+        }
+
+        if (this._unlockSignalId && this._unlockNotificationBox) {
+            this._unlockNotificationBox.disconnect(this._unlockSignalId);
+            this._unlockSignalId = null;
+            this._unlockNotificationBox = null;
         }
 
         this.progressBarManager?.destroy();

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,5 @@
   "session-modes": [ "user", "unlock-dialog" ],
   "url": "https://github.com/Krypion17/media-progress",
   "uuid": "media-progress@krypion17",
-  "version": 16
+  "version": 33
 }

--- a/progressBar.js
+++ b/progressBar.js
@@ -86,36 +86,41 @@ export class ProgressBarManager extends Slider {
     }
 
     _addProgress(name, owners, newOwner, oldOwner) {
-        for (const message of this._messages) {
-            if (message?._player?._busName !== name)
-                continue;
+        for (const message of this._messages ?? []) {
+            try {
+                if (message?._player?._busName !== name)
+                    continue;
 
-            if (owners && !newOwner && oldOwner)
+                if (owners && !newOwner && oldOwner)
+                    return;
+
+                const messageChild = message?.get_child?.();
+                const lastChild = messageChild?.get_last_child?.();
+                if (lastChild?.get_n_children?.() >= 2 && lastChild.get_child_at_index?.(1) instanceof ProgressBar)
+                    return;
+
+                if (!messageChild?.add_child)
+                    continue;
+
+                const timestamp1 = new St.Label({ style_class: "progressbar-timestamp" });
+                const timestamp2 = new St.Label({ style_class: "progressbar-timestamp" });
+                timestamp1.set_text(ZERO_TIMESTAMP);
+                timestamp2.set_text(ZERO_TIMESTAMP);
+
+                const progressBar = new ProgressBar(0, this, name, [timestamp1, timestamp2]);
+                const box = new St.BoxLayout();
+                box.add_child(timestamp1);
+                box.add_child(progressBar);
+                box.add_child(timestamp2);
+                messageChild.add_child(box);
+
+                this.bars[name] = progressBar;
+                void this._updateInitialLength(name, timestamp2);
                 return;
-
-            const messageChild = message.get_child();
-            const lastChild = messageChild?.get_last_child();
-            if (lastChild?.get_n_children() >= 2 && lastChild.get_child_at_index(1) instanceof ProgressBar)
+            } catch (error) {
+                _reportError(`Failed to add progress bar for ${name}`, error);
                 return;
-
-            if (!messageChild)
-                return;
-
-            const timestamp1 = new St.Label({ style_class: "progressbar-timestamp" });
-            const timestamp2 = new St.Label({ style_class: "progressbar-timestamp" });
-            timestamp1.set_text(ZERO_TIMESTAMP);
-            timestamp2.set_text(ZERO_TIMESTAMP);
-
-            const progressBar = new ProgressBar(0, this, name, [timestamp1, timestamp2]);
-            const box = new St.BoxLayout();
-            box.add_child(timestamp1);
-            box.add_child(progressBar);
-            box.add_child(timestamp2);
-            messageChild.add_child(box);
-
-            this.bars[name] = progressBar;
-            void this._updateInitialLength(name, timestamp2);
-            return;
+            }
         }
     }
 
@@ -177,8 +182,8 @@ export class ProgressBarManager extends Slider {
             if (!name.startsWith(MPRIS_BUS_PREFIX))
                 return;
 
-            for (const player of this._mediaSource.players) {
-                if (player._busName !== name)
+            for (const player of this._mediaSource?.players ?? []) {
+                if (!player?._busName || player._busName !== name)
                     continue;
 
                 if (this.signals[name]) {
@@ -215,7 +220,10 @@ export class ProgressBarManager extends Slider {
             delete this.bars[name];
         }
 
-        for (const player of this._mediaSource.players) {
+        for (const player of this._mediaSource?.players ?? []) {
+            if (!player?._busName)
+                continue;
+
             const signalId = this.signals[player._busName];
             if (!signalId)
                 continue;
@@ -294,6 +302,9 @@ export class ProgressBar extends Slider {
     }
 
     _setTimestampText(index, text) {
+        if (this._destroyed || !this.get_parent?.())
+            return;
+
         const label = this.timestamps?.[index];
         if (!label?.get_parent())
             return;
@@ -306,7 +317,10 @@ export class ProgressBar extends Slider {
     }
 
     _setTimestampsVisible(visible) {
-        for (const label of this.timestamps) {
+        if (this._destroyed || !this.get_parent?.())
+            return;
+
+        for (const label of this.timestamps ?? []) {
             if (label)
                 label.visible = visible;
         }
@@ -437,6 +451,9 @@ export class ProgressBar extends Slider {
     }
 
     _updateSettings() {
+        if (this._destroyed || !this.get_parent?.())
+            return;
+
         const osName = GLib.get_os_info("NAME") ?? "";
         const isUbuntu = osName.includes("Ubuntu");
         if (isUbuntu)

--- a/progressBar.js
+++ b/progressBar.js
@@ -1,63 +1,138 @@
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import GObject from "gi://GObject";
-import St from 'gi://St';
+import St from "gi://St";
 
+import { Slider } from "resource:///org/gnome/shell/ui/slider.js";
+import { loadInterfaceXML } from "resource:///org/gnome/shell/misc/fileUtils.js";
 
-import {Slider} from 'resource:///org/gnome/shell/ui/slider.js';
+const LOG_PREFIX = "media-progress";
 
-import { loadInterfaceXML } from 'resource:///org/gnome/shell/misc/fileUtils.js';
+const DBUS_NAME = "org.freedesktop.DBus";
+const DBUS_PATH = "/org/freedesktop/DBus";
+const DBUS_INTERFACE = "org.freedesktop.DBus";
+const DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties";
+const DBUS_PROPERTIES_GET_METHOD = "Get";
+
+const MPRIS_BUS_PREFIX = "org.mpris.MediaPlayer2.";
+const MPRIS_PATH = "/org/mpris/MediaPlayer2";
+const MPRIS_PLAYER_INTERFACE = "org.mpris.MediaPlayer2.Player";
+const MPRIS_SET_POSITION_METHOD = "SetPosition";
+
+const NAME_OWNER_DEBOUNCE_MS = 500;
+const DBUS_CALL_TIMEOUT_MS = 1000;
+const POLL_INTERVAL_MS = 1000;
+const MICROSECONDS_PER_SECOND = 1000000;
+const ZERO_TIMESTAMP = "0:00";
+const MIN_SLIDER_VALUE = 0;
+const MAX_SLIDER_VALUE = 1;
+const TIME_START_INDEX = 11;
+const TIME_END_INDEX = 19;
+
+const TRANSIENT_DBUS_ERROR_FRAGMENTS = [
+    "org.freedesktop.DBus.Error.NameHasNoOwner",
+    "org.freedesktop.DBus.Error.ServiceUnknown",
+    "org.freedesktop.DBus.Error.UnknownObject",
+    "org.freedesktop.DBus.Error.UnknownMethod",
+    "org.freedesktop.DBus.Error.NoReply",
+    "Gio.IOErrorEnum.CANCELLED",
+    "The connection is closed",
+];
+
+const DBUS_PROXY_WRAPPER = Gio.DBusProxy.makeProxyWrapper(loadInterfaceXML(DBUS_INTERFACE));
+const MPRIS_PLAYER_PROXY_WRAPPER = Gio.DBusProxy.makeProxyWrapper(loadInterfaceXML(MPRIS_PLAYER_INTERFACE));
+
+function _errorToString(error) {
+    if (!error)
+        return "unknown error";
+    if (error.message)
+        return error.message;
+    return String(error);
+}
+
+function _isTransientDbusError(error) {
+    const message = _errorToString(error);
+    return TRANSIENT_DBUS_ERROR_FRAGMENTS.some(fragment => message.includes(fragment));
+}
+
+function _reportError(context, error, { ignoreTransientDbus = false } = {}) {
+    if (ignoreTransientDbus && _isTransientDbusError(error))
+        return;
+
+    const detail = `[${LOG_PREFIX}] ${context}`;
+    if (error && typeof logError === "function") {
+        logError(error, detail);
+        return;
+    }
+
+    log(`${detail}: ${_errorToString(error)}`);
+}
 
 export class ProgressBarManager extends Slider {
     _init(mediaSource, messages) {
         super._init(0);
-        
-        const DBusIface = loadInterfaceXML('org.freedesktop.DBus');
-        const DBusProxy = Gio.DBusProxy.makeProxyWrapper(DBusIface);
 
-        this._dbusProxy = new DBusProxy(Gio.DBus.session, 
-                             'org.freedesktop.DBus',
-                             '/org/freedesktop/DBus',
-                             this._onProxyReady.bind(this));
-
+        this._dbusProxy = new DBUS_PROXY_WRAPPER(
+            Gio.DBus.session,
+            DBUS_NAME,
+            DBUS_PATH,
+            this._onProxyReady.bind(this)
+        );
 
         this._mediaSource = mediaSource;
         this._messages = messages;
-
-        
         this.signals = {};
         this.bars = {};
     }
 
     _addProgress(name, owners, newOwner, oldOwner) {
-        for (let i of this._messages) {
-            if (i._player._busName === name) {
-                if (owners && !newOwner && oldOwner)
-                    return;
-                    
-                if (i.get_child().get_last_child()?.get_n_children() >= 2 && i.get_child().get_last_child().get_child_at_index(1) instanceof ProgressBar) {
-                    return;
-                }
+        for (const message of this._messages) {
+            if (message?._player?._busName !== name)
+                continue;
 
-                let timestamp1 = new St.Label({
-                    style_class: "progressbar-timestamp"
-                });
-                timestamp1.set_text("0:00");
+            if (owners && !newOwner && oldOwner)
+                return;
 
-                let timestamp2 = new St.Label({
-                    style_class: "progressbar-timestamp"
-                });
-                timestamp2.set_text("0:00");
+            const messageChild = message.get_child();
+            const lastChild = messageChild?.get_last_child();
+            if (lastChild?.get_n_children() >= 2 && lastChild.get_child_at_index(1) instanceof ProgressBar)
+                return;
 
-                let progressBar = new ProgressBar(0, this, name, [timestamp1, timestamp2]);
-                let box = new St.BoxLayout();
-                box.add_child(timestamp1);
-                box.add_child(progressBar);
-                box.add_child(timestamp2);
-                i.get_child().add_child(box);
-                this.bars[name] = progressBar;
-                void this._updateInitialLength(name, timestamp2);
-            }
+            if (!messageChild)
+                return;
+
+            const timestamp1 = new St.Label({ style_class: "progressbar-timestamp" });
+            const timestamp2 = new St.Label({ style_class: "progressbar-timestamp" });
+            timestamp1.set_text(ZERO_TIMESTAMP);
+            timestamp2.set_text(ZERO_TIMESTAMP);
+
+            const progressBar = new ProgressBar(0, this, name, [timestamp1, timestamp2]);
+            const box = new St.BoxLayout();
+            box.add_child(timestamp1);
+            box.add_child(progressBar);
+            box.add_child(timestamp2);
+            messageChild.add_child(box);
+
+            this.bars[name] = progressBar;
+            void this._updateInitialLength(name, timestamp2);
+            return;
+        }
+    }
+
+    _formatDuration(seconds) {
+        const text = new Date(0);
+        text.setUTCSeconds(Math.max(0, seconds));
+        return text.toISOString().substring(TIME_START_INDEX, TIME_END_INDEX).replace(/^0(?:0:0?)?/, "");
+    }
+
+    _setTimestampText(timestamp, seconds) {
+        if (!timestamp?.get_parent() || !Number.isFinite(seconds) || seconds <= 0)
+            return;
+
+        try {
+            timestamp.set_text(this._formatDuration(seconds));
+        } catch (error) {
+            _reportError("Failed to update initial duration label", error);
         }
     }
 
@@ -65,78 +140,100 @@ export class ProgressBarManager extends Slider {
         try {
             const reply = await Gio.DBus.session.call(
                 name,
-                "/org/mpris/MediaPlayer2",
-                "org.freedesktop.DBus.Properties",
-                "Get",
-                new GLib.Variant("(ss)", ["org.mpris.MediaPlayer2.Player", "Metadata"]),
+                MPRIS_PATH,
+                DBUS_PROPERTIES_INTERFACE,
+                DBUS_PROPERTIES_GET_METHOD,
+                new GLib.Variant("(ss)", [MPRIS_PLAYER_INTERFACE, "Metadata"]),
                 null,
                 Gio.DBusCallFlags.NONE,
-                1000,
+                DBUS_CALL_TIMEOUT_MS,
                 null
             );
             const metadata = reply.recursiveUnpack()[0];
-            const seconds = Number(metadata?.['mpris:length'] ?? 0) / 1000000;
-
-            if (!timestamp.get_parent() || !seconds)
-                return;
-
-            let length = new Date(0);
-            length.setSeconds(seconds);
-            timestamp.set_text(length.toISOString().substring(11, 19).replace(/^0(?:0:0?)?/, ''));
-        } catch {}
+            const seconds = Number(metadata?.["mpris:length"] ?? 0) / MICROSECONDS_PER_SECOND;
+            this._setTimestampText(timestamp, seconds);
+        } catch (error) {
+            _reportError(`Failed to fetch initial metadata for ${name}`, error, { ignoreTransientDbus: true });
+        }
     }
 
     async _onProxyReady() {
         let names = [];
         try {
             [names] = await this._dbusProxy.ListNamesAsync();
-        } catch {
+        } catch (error) {
+            _reportError("Failed to list MPRIS DBus names", error, { ignoreTransientDbus: true });
             return;
         }
 
-        names.forEach(name => {
-            if (!name.startsWith('org.mpris.MediaPlayer2.'))
-                return;
+        for (const name of names) {
+            if (!name.startsWith(MPRIS_BUS_PREFIX))
+                continue;
 
             this._addProgress(name, false);
-        });
-        this.dbusSignal = this._dbusProxy.connectSignal("NameOwnerChanged", (pproxy, sender, [name, oldOwner, newOwner]) => {
-            if (!name.startsWith('org.mpris.MediaPlayer2.'))
+        }
+
+        this.dbusSignal = this._dbusProxy.connectSignal("NameOwnerChanged", (_proxy, _sender, [name, oldOwner, newOwner]) => {
+            if (!name.startsWith(MPRIS_BUS_PREFIX))
                 return;
+
             for (const player of this._mediaSource.players) {
-                if (player._busName == name) {
-                    this.signals[name] = player.connect('changed', () => {
-                        this._addProgress(name, true, newOwner, oldOwner);
-                    });
+                if (player._busName !== name)
+                    continue;
+
+                if (this.signals[name]) {
+                    try {
+                        player.disconnect(this.signals[name]);
+                    } catch (error) {
+                        _reportError(`Failed to disconnect old media signal for ${name}`, error);
+                    }
                 }
+
+                this.signals[name] = player.connect("changed", () => {
+                    this._addProgress(name, true, newOwner, oldOwner);
+                });
             }
 
+            clearTimeout(this.timeout);
             this.timeout = setTimeout(() => {
                 this._addProgress(name, true, newOwner, oldOwner);
-            }, 500);
+            }, NAME_OWNER_DEBOUNCE_MS);
         });
     }
 
     destroy() {
         clearTimeout(this.timeout);
 
-        for (let i in this.bars) {
-            if (!this.bars[i])
+        for (const [name, bar] of Object.entries(this.bars)) {
+            if (!bar)
                 continue;
-            this.bars[i].get_parent().destroy();
-            delete this.bars[i];
+            try {
+                bar.get_parent()?.destroy();
+            } catch (error) {
+                _reportError(`Failed to destroy progress bar actor for ${name}`, error);
+            }
+            delete this.bars[name];
         }
 
         for (const player of this._mediaSource.players) {
-            const _id = this.signals[player._busName];
-            if (_id) {
-                try { player.disconnect(_id); } catch (e) {}
-                delete this.signals[player._busName];
+            const signalId = this.signals[player._busName];
+            if (!signalId)
+                continue;
+
+            try {
+                player.disconnect(signalId);
+            } catch (error) {
+                _reportError(`Failed to disconnect player signal for ${player._busName}`, error);
             }
+            delete this.signals[player._busName];
         }
 
         if (this.dbusSignal) {
-            try { this._dbusProxy.disconnectSignal(this.dbusSignal); } catch (e) {}
+            try {
+                this._dbusProxy.disconnectSignal(this.dbusSignal);
+            } catch (error) {
+                _reportError("Failed to disconnect DBus NameOwnerChanged signal", error);
+            }
             this.dbusSignal = null;
         }
 
@@ -152,9 +249,9 @@ export class ProgressBar extends Slider {
         this.manager = manager;
         this.timestamps = timestamps;
         this._updateSettings();
-        this.updateSignal = St.Settings.get().connect('notify', () => this._updateSettings());
-        this._length = 1;
-        this._requestTimeoutMs = 1000;
+        this.updateSignal = St.Settings.get().connect("notify", () => this._updateSettings());
+        this._length = 0;
+        this._requestTimeoutMs = DBUS_CALL_TIMEOUT_MS;
         this._refreshInProgress = false;
         this._updateInProgress = false;
         this._destroyed = false;
@@ -165,7 +262,7 @@ export class ProgressBar extends Slider {
 
         this.interval = setInterval(() => {
             void this._refresh();
-        }, 1000);
+        }, POLL_INTERVAL_MS);
 
         this.signals.push(
             this.connect("drag-end", () => {
@@ -178,9 +275,9 @@ export class ProgressBar extends Slider {
     }
 
     _formatDuration(seconds) {
-        let text = new Date(0);
+        const text = new Date(0);
         text.setUTCSeconds(Math.max(0, seconds));
-        return text.toISOString().substring(11, 19).replace(/^0(?:0:0?)?/, '');
+        return text.toISOString().substring(TIME_START_INDEX, TIME_END_INDEX).replace(/^0(?:0:0?)?/, "");
     }
 
     _coerceNumber(value) {
@@ -188,8 +285,31 @@ export class ProgressBar extends Slider {
             return value;
         if (typeof value === "bigint")
             return Number(value);
-        let number = Number(value ?? 0);
+        const number = Number(value ?? 0);
         return Number.isFinite(number) ? number : 0;
+    }
+
+    _microsToSeconds(value) {
+        return this._coerceNumber(value) / MICROSECONDS_PER_SECOND;
+    }
+
+    _setTimestampText(index, text) {
+        const label = this.timestamps?.[index];
+        if (!label?.get_parent())
+            return;
+
+        try {
+            label.set_text(text);
+        } catch (error) {
+            _reportError(`Failed to update timestamp label ${index} for ${this._busName}`, error);
+        }
+    }
+
+    _setTimestampsVisible(visible) {
+        for (const label of this.timestamps) {
+            if (label)
+                label.visible = visible;
+        }
     }
 
     async _refresh() {
@@ -218,12 +338,11 @@ export class ProgressBar extends Slider {
             if (!this._length)
                 return;
 
-            this.value = Math.max(0, Math.min(1, position / this._length));
-            try {
-                this.timestamps[0].set_text(this._formatDuration(position / 1000000));
-            } catch {}
-        } catch {}
-        finally {
+            this.value = Math.max(MIN_SLIDER_VALUE, Math.min(MAX_SLIDER_VALUE, position / this._length));
+            this._setTimestampText(0, this._formatDuration(this._microsToSeconds(position)));
+        } catch (error) {
+            _reportError(`Failed to refresh progress for ${this._busName}`, error, { ignoreTransientDbus: true });
+        } finally {
             this._refreshInProgress = false;
         }
     }
@@ -241,27 +360,23 @@ export class ProgressBar extends Slider {
                 return;
 
             const metadata = await this.getProperty("Metadata");
-            this._trackId = metadata?.['mpris:trackid'] ?? 0;
+            this._trackId = metadata?.["mpris:trackid"] ?? 0;
             const canSeek = Boolean(await this.getProperty("CanSeek"));
             this.reactive = Boolean(this._trackId) && canSeek;
 
-            this._length = this._coerceNumber(metadata?.['mpris:length'] ?? 0);
+            this._length = this._coerceNumber(metadata?.["mpris:length"] ?? 0);
             if (!this._length) {
                 this.visible = false;
-                this.timestamps[0].visible = false;
-                this.timestamps[1].visible = false;
+                this._setTimestampsVisible(false);
                 return;
             }
 
             this.visible = true;
-            this.timestamps[0].visible = true;
-            this.timestamps[1].visible = true;
-
-            try {
-                this.timestamps[1].set_text(this._formatDuration(this._length / 1000000));
-            } catch {}
-        } catch {}
-        finally {
+            this._setTimestampsVisible(true);
+            this._setTimestampText(1, this._formatDuration(this._microsToSeconds(this._length)));
+        } catch (error) {
+            _reportError(`Failed to update metadata for ${this._busName}`, error, { ignoreTransientDbus: true });
+        } finally {
             this._updateInProgress = false;
         }
     }
@@ -273,16 +388,17 @@ export class ProgressBar extends Slider {
         try {
             return (await this._playerProxy.get_connection().call(
                 this._busName,
-                "/org/mpris/MediaPlayer2",
-                "org.freedesktop.DBus.Properties",
-                "Get",
-                new GLib.Variant("(ss)", ["org.mpris.MediaPlayer2.Player", prop]),
+                MPRIS_PATH,
+                DBUS_PROPERTIES_INTERFACE,
+                DBUS_PROPERTIES_GET_METHOD,
+                new GLib.Variant("(ss)", [MPRIS_PLAYER_INTERFACE, prop]),
                 null,
                 Gio.DBusCallFlags.NONE,
                 this._requestTimeoutMs,
                 null
             )).recursiveUnpack()[0];
-        } catch {
+        } catch (error) {
+            _reportError(`Failed to read ${prop} for ${this._busName}`, error, { ignoreTransientDbus: true });
             return null;
         }
     }
@@ -298,62 +414,90 @@ export class ProgressBar extends Slider {
         try {
             await this._playerProxy.get_connection().call(
                 this._busName,
-                "/org/mpris/MediaPlayer2",
-                "org.mpris.MediaPlayer2.Player",
-                "SetPosition",
+                MPRIS_PATH,
+                MPRIS_PLAYER_INTERFACE,
+                MPRIS_SET_POSITION_METHOD,
                 new GLib.Variant("(ox)", [this._trackId, Math.round(this._coerceNumber(value))]),
                 null,
                 Gio.DBusCallFlags.NONE,
                 this._requestTimeoutMs,
                 null
             );
-        } catch {}
+        } catch (error) {
+            _reportError(`Failed to set position for ${this._busName}`, error, { ignoreTransientDbus: true });
+        }
     }
-           
+
     _onPlayerProxyReady() {
-        this._playerProxy.connectObject('g-properties-changed', () => void this._updateInfo(), this);
+        if (!this._playerProxy || this._destroyed)
+            return;
+
+        this._playerProxy.connectObject("g-properties-changed", () => void this._updateInfo(), this);
         void this._updateInfo();
     }
 
     _updateSettings() {
-        if (GLib.get_os_info("NAME").includes("Ubuntu"))
+        const osName = GLib.get_os_info("NAME") ?? "";
+        const isUbuntu = osName.includes("Ubuntu");
+        if (isUbuntu)
             this.add_style_class_name("progress-bar-ubuntu");
         else
             this.remove_style_class_name("progress-bar-ubuntu");
 
-        if (St.Settings.get().color_scheme === 0 && GLib.get_os_info("NAME").includes("Ubuntu")) {
-            this.remove_style_class_name('progress-bar');
-            this.add_style_class_name('progress-bar-light');
-        } else if (St.Settings.get().color_scheme === 2) {
-            this.remove_style_class_name('progress-bar');
-            this.add_style_class_name('progress-bar-light');
-        } else {
-            this.remove_style_class_name('progress-bar-light');
-            this.add_style_class_name('progress-bar');
+        if ((St.Settings.get().color_scheme === 0 && isUbuntu) || St.Settings.get().color_scheme === 2) {
+            this.remove_style_class_name("progress-bar");
+            this.add_style_class_name("progress-bar-light");
+            return;
         }
+
+        this.remove_style_class_name("progress-bar-light");
+        this.add_style_class_name("progress-bar");
     }
 
     _initProxy() {
         try {
-            const MprisPlayerIface = loadInterfaceXML('org.mpris.MediaPlayer2.Player');
-            const MprisPlayerProxy = Gio.DBusProxy.makeProxyWrapper(MprisPlayerIface);
-
-            this._playerProxy = new MprisPlayerProxy(Gio.DBus.session, this._busName, '/org/mpris/MediaPlayer2', this._onPlayerProxyReady.bind(this));
-        } catch {}
+            this._playerProxy = new MPRIS_PLAYER_PROXY_WRAPPER(
+                Gio.DBus.session,
+                this._busName,
+                MPRIS_PATH,
+                this._onPlayerProxyReady.bind(this)
+            );
+        } catch (error) {
+            _reportError(`Failed to initialize MPRIS proxy for ${this._busName}`, error, { ignoreTransientDbus: true });
+        }
     }
 
     _onDestroy() {
         this._destroyed = true;
-        this.signals.map((i) => {
-            this.disconnect(i);
-        });
-        if (this._playerProxy) {
-            try { this._playerProxy.disconnectObject(this); } catch {}
+        for (const signalId of this.signals) {
+            try {
+                this.disconnect(signalId);
+            } catch (error) {
+                _reportError(`Failed to disconnect local signal ${signalId} for ${this._busName}`, error);
+            }
         }
-        if (this.updateSignal) { try { St.Settings.get().disconnect(this.updateSignal); } catch (e) {} this.updateSignal = null; }
+
+        if (this._playerProxy) {
+            try {
+                this._playerProxy.disconnectObject(this);
+            } catch (error) {
+                _reportError(`Failed to disconnect proxy object for ${this._busName}`, error);
+            }
+        }
+
+        if (this.updateSignal) {
+            try {
+                St.Settings.get().disconnect(this.updateSignal);
+            } catch (error) {
+                _reportError(`Failed to disconnect settings signal for ${this._busName}`, error);
+            }
+            this.updateSignal = null;
+        }
+
         clearInterval(this.interval);
         this._playerProxy = null;
-        if (this.manager.bars[this._busName])
+
+        if (this.manager?.bars?.[this._busName])
             delete this.manager.bars[this._busName];
     }
 }

--- a/progressBar.js
+++ b/progressBar.js
@@ -39,28 +39,6 @@ export class ProgressBarManager extends Slider {
                     return;
                 }
 
-                let seconds = 0;
-
-                const MprisPlayerIface = loadInterfaceXML('org.mpris.MediaPlayer2.Player');
-                const MprisPlayerProxy = Gio.DBusProxy.makeProxyWrapper(MprisPlayerIface);
-
-                let playerProxy = new MprisPlayerProxy(Gio.DBus.session, name, '/org/mpris/MediaPlayer2', () => {
-                    try {
-                        seconds = playerProxy.get_connection().call_sync(
-                            name,
-                            "/org/mpris/MediaPlayer2",
-                            "org.freedesktop.DBus.Properties",
-                            "Get",
-                            new GLib.Variant("(ss)", ["org.mpris.MediaPlayer2.Player", "Metadata"]),
-                            null,
-                            Gio.DBusCallFlags.NONE,
-                            50,
-                            null
-                        ).recursiveUnpack()[0]['mpris:length'] / 1000000;
-                    } catch {
-                        return;
-                    }
-                });
                 let timestamp1 = new St.Label({
                     style_class: "progressbar-timestamp"
                 });
@@ -69,23 +47,53 @@ export class ProgressBarManager extends Slider {
                 let timestamp2 = new St.Label({
                     style_class: "progressbar-timestamp"
                 });
+                timestamp2.set_text("0:00");
 
                 let progressBar = new ProgressBar(0, this, name, [timestamp1, timestamp2]);
                 let box = new St.BoxLayout();
-                let length = new Date(0);
-                length.setSeconds(seconds);
-                timestamp2.set_text(length.toISOString().substring(11,19).replace(/^0(?:0:0?)?/, ''));
                 box.add_child(timestamp1);
                 box.add_child(progressBar);
                 box.add_child(timestamp2);
                 i.get_child().add_child(box);
                 this.bars[name] = progressBar;
+                void this._updateInitialLength(name, timestamp2);
             }
         }
     }
 
+    async _updateInitialLength(name, timestamp) {
+        try {
+            const reply = await Gio.DBus.session.call(
+                name,
+                "/org/mpris/MediaPlayer2",
+                "org.freedesktop.DBus.Properties",
+                "Get",
+                new GLib.Variant("(ss)", ["org.mpris.MediaPlayer2.Player", "Metadata"]),
+                null,
+                Gio.DBusCallFlags.NONE,
+                1000,
+                null
+            );
+            const metadata = reply.recursiveUnpack()[0];
+            const seconds = Number(metadata?.['mpris:length'] ?? 0) / 1000000;
+
+            if (!timestamp.get_parent() || !seconds)
+                return;
+
+            let length = new Date(0);
+            length.setSeconds(seconds);
+            timestamp.set_text(length.toISOString().substring(11, 19).replace(/^0(?:0:0?)?/, ''));
+        } catch {}
+    }
+
     async _onProxyReady() {
-        const [names] = await this._dbusProxy.ListNamesAsync().catch();
+        let names = [];
+        try {
+            [names] = await this._dbusProxy.ListNamesAsync();
+        } catch {
+            return;
+        }
+
         names.forEach(name => {
             if (!name.startsWith('org.mpris.MediaPlayer2.'))
                 return;
@@ -146,30 +154,17 @@ export class ProgressBar extends Slider {
         this._updateSettings();
         this.updateSignal = St.Settings.get().connect('notify', () => this._updateSettings());
         this._length = 1;
+        this._requestTimeoutMs = 1000;
+        this._refreshInProgress = false;
+        this._updateInProgress = false;
+        this._destroyed = false;
 
         this.signals = [];
 
         this._initProxy();
 
         this.interval = setInterval(() => {
-            if (this._dragging)
-                return;
-            if (!this.length)
-                this._updateInfo();
-
-            let position;
-            if (this.getProperty("PlaybackStatus") === "Playing")
-                position = this.getProperty("Position");
-            else
-                position = this.value * this._length;
-
-            this.value = position / this._length;
-            position = position / 1000000;
-            let text = new Date(0);
-            text.setUTCSeconds(position);
-            try {
-                this.timestamps[0].set_text(text.toISOString().substring(11,19).replace(/^0(?:0:0?)?/, ''));
-            } catch {}
+            void this._refresh();
         }, 1000);
 
         this.signals.push(
@@ -182,37 +177,101 @@ export class ProgressBar extends Slider {
         );
     }
 
-    _updateInfo() {
-        if (!this._playerProxy)
-            this._initProxy();
-        this._trackId = this.getProperty("Metadata")['mpris:trackid'];
-        if (!this._trackId)
-            this.reactive = false;
-        if (this._trackId !== 0 && this.getProperty("CanSeek"))
-            this.reactive = true;
-        this._length = this.getProperty("Metadata")['mpris:length'];
-        if (!this._length) {
-            this.visible = false;
-            this.timestamps[0].visible = false;
-            this.timestamps[1].visible = false;
+    _formatDuration(seconds) {
+        let text = new Date(0);
+        text.setUTCSeconds(Math.max(0, seconds));
+        return text.toISOString().substring(11, 19).replace(/^0(?:0:0?)?/, '');
+    }
+
+    _coerceNumber(value) {
+        if (typeof value === "number")
+            return value;
+        if (typeof value === "bigint")
+            return Number(value);
+        let number = Number(value ?? 0);
+        return Number.isFinite(number) ? number : 0;
+    }
+
+    async _refresh() {
+        if (this._destroyed || this._refreshInProgress)
             return;
-        } else {
+
+        this._refreshInProgress = true;
+        try {
+            if (this._dragging)
+                return;
+
+            if (!this._length)
+                await this._updateInfo();
+
+            if (!this._length)
+                return;
+
+            let position = this.value * this._length;
+            const playbackStatus = await this.getProperty("PlaybackStatus");
+            if (playbackStatus === "Playing") {
+                const remotePosition = await this.getProperty("Position");
+                if (remotePosition !== null)
+                    position = this._coerceNumber(remotePosition);
+            }
+
+            if (!this._length)
+                return;
+
+            this.value = Math.max(0, Math.min(1, position / this._length));
+            try {
+                this.timestamps[0].set_text(this._formatDuration(position / 1000000));
+            } catch {}
+        } catch {}
+        finally {
+            this._refreshInProgress = false;
+        }
+    }
+
+    async _updateInfo() {
+        if (this._destroyed || this._updateInProgress)
+            return;
+
+        this._updateInProgress = true;
+        try {
+            if (!this._playerProxy)
+                this._initProxy();
+
+            if (!this._playerProxy)
+                return;
+
+            const metadata = await this.getProperty("Metadata");
+            this._trackId = metadata?.['mpris:trackid'] ?? 0;
+            const canSeek = Boolean(await this.getProperty("CanSeek"));
+            this.reactive = Boolean(this._trackId) && canSeek;
+
+            this._length = this._coerceNumber(metadata?.['mpris:length'] ?? 0);
+            if (!this._length) {
+                this.visible = false;
+                this.timestamps[0].visible = false;
+                this.timestamps[1].visible = false;
+                return;
+            }
+
             this.visible = true;
             this.timestamps[0].visible = true;
             this.timestamps[1].visible = true;
-        }
 
-        let position = this._length / 1000000;
-        let text = new Date(0);
-        text.setUTCSeconds(position);
-        try {
-            this.timestamps[1].set_text(text.toISOString().substring(11,19).replace(/^0(?:0:0?)?/, ''));
+            try {
+                this.timestamps[1].set_text(this._formatDuration(this._length / 1000000));
+            } catch {}
         } catch {}
+        finally {
+            this._updateInProgress = false;
+        }
     }
 
-    getProperty(prop) {
+    async getProperty(prop) {
+        if (!this._playerProxy)
+            return null;
+
         try {
-            return this._playerProxy.get_connection().call_sync(
+            return (await this._playerProxy.get_connection().call(
                 this._busName,
                 "/org/mpris/MediaPlayer2",
                 "org.freedesktop.DBus.Properties",
@@ -220,31 +279,40 @@ export class ProgressBar extends Slider {
                 new GLib.Variant("(ss)", ["org.mpris.MediaPlayer2.Player", prop]),
                 null,
                 Gio.DBusCallFlags.NONE,
-                50,
+                this._requestTimeoutMs,
                 null
-            ).recursiveUnpack()[0];
+            )).recursiveUnpack()[0];
         } catch {
-            return 0;
+            return null;
         }
     }
 
     setPosition(value) {
-        this._playerProxy.get_connection().call_sync(
-            this._busName,
-            "/org/mpris/MediaPlayer2",
-            "org.mpris.MediaPlayer2.Player",
-            "SetPosition",
-            new GLib.Variant("(ox)", [this._trackId, value.toString()]),
-            null,
-            Gio.DBusCallFlags.NONE,
-            50,
-            null
-        );
+        void this._setPositionAsync(value);
+    }
+
+    async _setPositionAsync(value) {
+        if (!this._playerProxy || !this._trackId)
+            return;
+
+        try {
+            await this._playerProxy.get_connection().call(
+                this._busName,
+                "/org/mpris/MediaPlayer2",
+                "org.mpris.MediaPlayer2.Player",
+                "SetPosition",
+                new GLib.Variant("(ox)", [this._trackId, Math.round(this._coerceNumber(value))]),
+                null,
+                Gio.DBusCallFlags.NONE,
+                this._requestTimeoutMs,
+                null
+            );
+        } catch {}
     }
            
     _onPlayerProxyReady() {
-        this._playerProxy.connectObject('g-properties-changed', () => this._updateInfo(), this);
-        this._updateInfo();
+        this._playerProxy.connectObject('g-properties-changed', () => void this._updateInfo(), this);
+        void this._updateInfo();
     }
 
     _updateSettings() {
@@ -270,15 +338,18 @@ export class ProgressBar extends Slider {
             const MprisPlayerIface = loadInterfaceXML('org.mpris.MediaPlayer2.Player');
             const MprisPlayerProxy = Gio.DBusProxy.makeProxyWrapper(MprisPlayerIface);
 
-            this._playerProxy = MprisPlayerProxy(Gio.DBus.session, this._busName, '/org/mpris/MediaPlayer2', this._onPlayerProxyReady.bind(this));
+            this._playerProxy = new MprisPlayerProxy(Gio.DBus.session, this._busName, '/org/mpris/MediaPlayer2', this._onPlayerProxyReady.bind(this));
         } catch {}
     }
 
     _onDestroy() {
+        this._destroyed = true;
         this.signals.map((i) => {
             this.disconnect(i);
         });
-        this._playerProxy.disconnectObject(this);
+        if (this._playerProxy) {
+            try { this._playerProxy.disconnectObject(this); } catch {}
+        }
         if (this.updateSignal) { try { St.Settings.get().disconnect(this.updateSignal); } catch (e) {} this.updateSignal = null; }
         clearInterval(this.interval);
         this._playerProxy = null;


### PR DESCRIPTION
Hey, 

first of all thank you for this extension!

It is a really nice idea and it makes the media notification much better.

I ran into a bad issue on my setup with GNOME 49 + aggressive process tuning, and I wanted to share what I changed in case it helps.

Also, I definitely went a bit overboard with refactoring.
Happy to break this down into smaller focused commits if that is preferred.

On my machine, scrolling in Firefox/LibreWolf could freeze/hang the desktop for short bursts.
At first it looked like a browser issue, but logs and code inspection pointed to this extension path:

- sync DBus calls (`call_sync`) running on GNOME Shell main thread
- these were called from frequent update paths
- when the media app was busy, shell could block waiting on DBus replies

I also saw noisy runtime errors around player/session churn (`_player`, `_busName`, `_mediaSource` sometimes absent) and many warnings about widgets not in stage.

## Changes

1. Removed blocking DBus calls
- replaced `call_sync` with async DBus calls (`call` + `await`)
- updated read/write property calls to avoid blocking shell UI thread

2. Added lifecycle and race guards
- made updates non-overlapping to avoid piling requests
- added checks for destroyed/missing actors before label/style updates
- added safer cleanup on destroy

3. Added null safety around dynamic GNOME internals
- guarded access to message/player/session objects that can disappear
- handled missing `_mediaSource`, `_player`, `_busName`, notification box, etc.

4. Some leanup
- moved magic numbers/DBus strings to top-level constants
- reduced repeated literals and cleaned up some flow
- replaced silent `catch {}` with explicit handling
- added filtered logging helper for transient DBus errors so normal churn does not spam too much

---

Like i said, I can split this refactor into smaller PR-friendly chunks, whichever is easiest to review.

Thanks again for building this extension!