### PR TITLE
Support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "description": "Progress Bar for the GNOME Media Notification",
   "name": "Media Progress",
   "shell-version": [
-    "49"
+    "50"
   ],
   "session-modes": [ "user", "unlock-dialog" ],
   "url": "https://github.com/Krypion17/media-progress",


### PR DESCRIPTION
Update metadata.json shell-version from 49 to 50